### PR TITLE
check that aditional image file exists

### DIFF
--- a/classes/amazon-s3-and-cloudfront.php
+++ b/classes/amazon-s3-and-cloudfront.php
@@ -153,7 +153,7 @@ class Amazon_S3_And_CloudFront extends AWS_Plugin_Base {
 		}
 
         $files_to_remove = array();
-        if (file_exists($file_path)) {
+        if ( file_exists( $file_path ) ) {
             $files_to_remove[] = $file_path;
             try {
                 $s3client->putObject( $args );


### PR DESCRIPTION
This is an additional fix for file updating. 

Before setting an additional image file for upload, it's necessary to check if the file exists. If the file doesn't exist it means that the image for that size was not edited.
