### PR TITLE
Allow buckets outside of US Default region to contain dots.

### DIFF
--- a/classes/amazon-s3-and-cloudfront.php
+++ b/classes/amazon-s3-and-cloudfront.php
@@ -58,6 +58,11 @@ class Amazon_S3_And_CloudFront extends AWS_Plugin_Base {
             return;
         }
 
+        $s3client = $this->get_s3client();
+
+        // Deleting images may fail when buckets name contains dots so we specify the region
+        $this->set_region_from_bucket( $s3object['bucket'] );
+
         $amazon_path = dirname( $s3object['key'] );
         $objects = array();
 
@@ -86,7 +91,7 @@ class Amazon_S3_And_CloudFront extends AWS_Plugin_Base {
         	}
 
 			try {
-		        $this->get_s3client()->deleteObjects( array( 
+				$s3client->deleteObjects( array( 
 		        	'Bucket' => $s3object['bucket'],
 		        	'Objects' => $hidpi_images
 		        ) );
@@ -99,7 +104,7 @@ class Amazon_S3_And_CloudFront extends AWS_Plugin_Base {
         );
 
 		try {
-	        $this->get_s3client()->deleteObjects( array( 
+			$s3client->deleteObjects( array( 
 	        	'Bucket' => $s3object['bucket'],
 	        	'Objects' => $objects
 	        ) );
@@ -137,6 +142,9 @@ class Amazon_S3_And_CloudFront extends AWS_Plugin_Base {
         $s3client = $this->get_s3client();
 
         $bucket = $this->get_setting( 'bucket' );
+
+		// Uploading may fail when buckets name contains dots so we specify the region
+		$this->set_region_from_bucket($bucket);
 
         $file_name = basename( $file_path );
 
@@ -235,6 +243,20 @@ class Amazon_S3_And_CloudFront extends AWS_Plugin_Base {
     		}
     	}
     }
+
+	function set_region_from_bucket( $bucket ) {
+		$s3client = $this->get_s3client();
+		$bucketLocation = $s3client->getBucketLocation(array('Bucket' => $bucket));
+		switch ($bucketLocation['Location']) {
+			case "":
+				break;
+			case "EU":
+				$s3client->setRegion('eu-west-1');
+				break;
+			default:
+				$s3client->setRegion($bucketLocation['Location']);
+		}
+	}
 
     function get_hidpi_file_path( $orig_path ) {
 		$hidpi_suffix = apply_filters( 'as3cf_hidpi_suffix', '@2x' );


### PR DESCRIPTION
Uploading failed when we were using buckets that contained dots in the file name. After a little testing we found out that buckets with dots worked for the US default region but not in other regions. I've added additional code that specifies the region based on the bucket location.
