### PR TITLE
Allow S3 bucket to be set via configuration file

### DIFF
--- a/classes/amazon-s3-and-cloudfront.php
+++ b/classes/amazon-s3-and-cloudfront.php
@@ -39,7 +39,7 @@ class Amazon_S3_And_CloudFront extends AWS_Plugin_Base {
 		}
 
 		// Allow bucket to be set via config file (useful for multiple enivornments)
-		if ( $key == 'bucket' & defined( 'S3_BUCKET' ) ) return S3_BUCKET;
+		if ( $key == 'bucket' && defined( 'S3_BUCKET' ) ) return S3_BUCKET;
 
 		return parent::get_setting( $key );
 	}


### PR DESCRIPTION
Very useful for multiple environments and works much like the Amazon Web Services plugin where you can set your access and secret keys in constant variables.
