### PR TITLE
Add blog_id to the S3 url

### DIFF
--- a/classes/amazon-s3-and-cloudfront.php
+++ b/classes/amazon-s3-and-cloudfront.php
@@ -905,7 +905,7 @@ class Amazon_S3_And_CloudFront extends AWS_Plugin_Base {
 
 	function get_dynamic_prefix( $time = null ) {
 		$uploads = wp_upload_dir( $time );
-		return str_replace( $this->get_base_upload_path(), '', $uploads['path'] );
+		return (is_multisite() ? get_current_blog_id() : '').str_replace( $this->get_base_upload_path(), '', $uploads['path'] );
 	}
 
 	// Without the multisite subdirectory


### PR DESCRIPTION
This change makes the plugin work better for WPMU sites by adding the blog_id to the file path if it is detected multisite is enabled.

Could be a little crude, and possibly made in to an option, but this serves my needs very nicely and is working well.