### PR TITLE
Always return http path link instead of local file path

### DIFF
--- a/classes/amazon-s3-and-cloudfront.php
+++ b/classes/amazon-s3-and-cloudfront.php
@@ -1142,7 +1142,7 @@ class Amazon_S3_And_CloudFront extends AWS_Plugin_Base {
 	 * @return string
 	 */
 	function get_attached_file( $file, $attachment_id ) {
-		if ( file_exists( $file ) || ! $this->get_setting( 'serve-from-s3' ) ) {
+		if ( ! $this->get_setting( 'serve-from-s3' ) ) {
 			return $file;
 		}
 


### PR DESCRIPTION
In some cases, returning local file path when the file exists locally can be problematic. For example, there are multiple server instances and this local file path is only valid in a specific instance where it is recently uploaded but it will be not the case in other servers. 
Especially when the local file path is passed to other instances for long-run tasks which demand for a http path (universal to everyone) instead. 

I believe the performance won't be affected much but we could avoid the aforementioned issue. 