### PR TITLE
Prevent fatal error in the event `get_client()` returns a WP_Error

### DIFF
--- a/classes/amazon-s3-and-cloudfront.php
+++ b/classes/amazon-s3-and-cloudfront.php
@@ -1819,7 +1819,11 @@ class Amazon_S3_And_CloudFront extends AWS_Plugin_Base {
 				$args = array();
 			}
 
-			$this->s3client = $this->aws->get_client()->get( 's3', $args );
+			$client = $this->aws->get_client();
+
+			if ( ! is_wp_error( $client ) ) {
+				$this->s3client = $client->get( 's3', $args );
+			}
 		}
 
 		return $this->s3client;

--- a/classes/as3cf-plugin-compatibility.php
+++ b/classes/as3cf-plugin-compatibility.php
@@ -629,6 +629,10 @@ class AS3CF_Plugin_Compatibility {
 		$client   = $this->as3cf->get_s3client( $region, true );
 		$protocol = $this->get_stream_wrapper_protocol( $region );
 
+		if ( ! $client instanceof \Aws\S3\S3Client ) {
+			return;
+		}
+
 		// Register the region specific S3 stream wrapper to be used by plugins
 		AS3CF_Stream_Wrapper::register( $client, $protocol );
 


### PR DESCRIPTION
This is a simple change which resolves an error I reported in #292.

Not sure if this is the best way to fix it, specifically the change to `register_stream_wrapper`, but it prevents the fatal.

Would be happy to include any other changes needed for a merge.