### PR TITLE
Create directory if not exists

### DIFF
--- a/classes/as3cf-plugin-compatibility.php
+++ b/classes/as3cf-plugin-compatibility.php
@@ -625,7 +625,7 @@ class AS3CF_Plugin_Compatibility {
 		try {
 			$directory = dirname($file);
 			if (!file_exists($directory)) {
-				mkdir($dir, 0777, true);
+				mkdir($dir, 0775, true);
 			}
 			
 			$this->as3cf->get_s3client( $s3_object['region'], true )->getObject(

--- a/classes/as3cf-plugin-compatibility.php
+++ b/classes/as3cf-plugin-compatibility.php
@@ -623,6 +623,11 @@ class AS3CF_Plugin_Compatibility {
 	 */
 	protected function copy_s3_file_to_server( $s3_object, $file ) {
 		try {
+			$directory = dirname($file);
+			if (!file_exists($directory)) {
+				mkdir($dir, 0777, true);
+			}
+			
 			$this->as3cf->get_s3client( $s3_object['region'], true )->getObject(
 				array(
 					'Bucket' => $s3_object['bucket'],

--- a/classes/as3cf-plugin-compatibility.php
+++ b/classes/as3cf-plugin-compatibility.php
@@ -625,7 +625,7 @@ class AS3CF_Plugin_Compatibility {
 		try {
 			$directory = dirname($file);
 			if (!file_exists($directory)) {
-				mkdir($dir, 0775, true);
+				mkdir($directory, 0775, true);
 			}
 			
 			$this->as3cf->get_s3client( $s3_object['region'], true )->getObject(


### PR DESCRIPTION
On EC2 current version throws errors of "file not exists" when the target directory doesn't exist. It may be a bug in AWS SDK, but still needs a fix to work correctly.