### PR TITLE
Allow setting of custom domain in wp-config

### DIFF
--- a/classes/amazon-s3-and-cloudfront.php
+++ b/classes/amazon-s3-and-cloudfront.php
@@ -287,6 +287,17 @@ class Amazon_S3_And_CloudFront extends AWS_Plugin_Base {
 			return $bucket;
 		}
 
+		if ( 'cloudfront' == $key && defined( 'AS3CF_DOMAIN' ) ) {
+			$cloudfront = AS3CF_DOMAIN;
+
+			if ( $cloudfront !== $value ) {
+				// Save the defined cloudfront
+				parent::set_setting( 'cloudfront', $cloudfront );
+			}
+
+			return $cloudfront;
+		}
+
 		return apply_filters( 'as3cf_setting_' . $key, $value );
 	}
 

--- a/view/domain-setting.php
+++ b/view/domain-setting.php
@@ -1,5 +1,8 @@
 <?php
-$tr_class = ( isset( $tr_class ) ) ? $tr_class : ''; ?>
+$constant = strtoupper( str_replace( '-', '_', $prefix ) . '_DOMAIN' );
+$tr_class = ( isset( $tr_class ) ) ? $tr_class : '';
+?>
+
 <tr class="<?php echo $tr_class; ?>">
 	<td>
 		<h4><?php _e( 'Domain:', 'amazon-s3-and-cloudfront' ) ?></h4>
@@ -37,7 +40,10 @@ $tr_class = ( isset( $tr_class ) ) ? $tr_class : ''; ?>
 				<input id="cloudfront" type="radio" name="domain" value="cloudfront" <?php checked( $domain, 'cloudfront' ); ?>>
 				<?php _e( 'CloudFront or custom domain', 'amazon-s3-and-cloudfront' ); ?>
 				<p class="as3cf-setting cloudfront <?php echo ( 'cloudfront' == $domain ) ? '' : 'hide'; // xss ok ?>">
-					<input type="text" name="cloudfront" value="<?php echo esc_attr( $this->get_setting( 'cloudfront' ) ); ?>" size="30" />
+					<input type="text" name="cloudfront" value="<?php echo esc_attr( $this->get_setting( 'cloudfront' ) ); ?>" size="30" <?php if ( defined( $constant ) ) { ?>disabled<?php } ?>/>
+					<?php if ( defined( $constant ) ) { ?>
+						<?php _e( '(defined in wp-config.php)', 'amazon-s3-and-cloudfront' );
+					} ?>
 					<span class="as3cf-validation-error" style="display: none;">
 						<?php _e( 'Invalid character. Letters, numbers, periods and hyphens are allowed.', 'amazon-s3-and-cloudfront' ); ?>
 					</span>

--- a/view/settings.php
+++ b/view/settings.php
@@ -76,7 +76,13 @@ $selected_bucket_prefix = $this->get_object_prefix(); ?>
 						</div>
 					</td>
 				</tr>
-				<?php $this->render_view( 'domain-setting', array( 'tr_class' => 'configure-url url-preview' ) ); ?>
+				<?php
+				$this->render_view( 'domain-setting',
+					array(
+						'prefix'                 => $prefix,
+						'tr_class'               => 'configure-url url-preview',
+					)
+				); ?>
 				<tr class="configure-url url-preview">
 					<td>
 						<?php $this->render_view( 'checkbox', array( 'key' => 'enable-object-prefix', 'class' => 'sub-toggle' ) ); ?>


### PR DESCRIPTION
Because we're running WordPress across environments (production, staging, testing), it's really useful for me to be able to set the custom domain (aka "cloudfront") in wp-config.php. This patch makes that possible with a constant named AS3CF_DOMAIN.