### PR TITLE
Fix Warnings and Notices on attachment url filter

### DIFF
--- a/classes/amazon-s3-and-cloudfront.php
+++ b/classes/amazon-s3-and-cloudfront.php
@@ -1861,7 +1861,7 @@ class Amazon_S3_And_CloudFront extends AWS_Plugin_Base {
 	 *
 	 * @return bool|mixed|void|WP_Error
 	 */
-	public function wp_get_attachment_url( $url, $post_id ) {
+	public function wp_get_attachment_url( $url, $post_id = null ) {
 		$new_url = $this->get_attachment_url( $post_id );
 
 		if ( false === $new_url ) {


### PR DESCRIPTION
Hi there,

I'm using your plugin to offload images to S3 when they're uploaded onto Wordpress. I've noticed a lot of PHP warnings and notices being generated by your plugin. The two I see a lot of are:

Warning: Missing argument 2 for Amazon_S3_And_CloudFront::wp_get_attachment_url() in .../plugins/amazon-s3-and-cloudfront/classes/amazon-s3-and-cloudfront.php on line 1864
Notice: Undefined variable: post_id in .../plugins/amazon-s3-and-cloudfront/classes/amazon-s3-and-cloudfront.php on line 1865


I've identified that the issue is that the filter 'wp_get_attachment_url', added in line 154 of 'classes/amazon-s3-and-cloudfront.php' of your plugin requires two parameters. However according to Wordpress only one will be provided - https://codex.wordpress.org/Plugin_API/Filter_Reference/wp_get_attachment_url

As such I've made this pull request to default the value of $post_id to null. 
