### PR TITLE
Fix sidebar position in rtl view

### DIFF
--- a/assets/sass/styles.scss
+++ b/assets/sass/styles.scss
@@ -573,6 +573,11 @@
 	top: 9px;
 	left: 670px;
 	width: 292px;
+	
+	body[dir="rtl"] & {
+		left: auto;
+		right: 670px;
+	}
 
 	.block {
 		padding: 20px;

--- a/assets/sass/styles.scss
+++ b/assets/sass/styles.scss
@@ -574,7 +574,7 @@
 	left: 670px;
 	width: 292px;
 	
-	body[dir="rtl"] & {
+	html[dir="rtl"] & {
 		left: auto;
 		right: 670px;
 	}


### PR DESCRIPTION
Hi there,
Added minor fix to the position of the sidebar in the settings page.
In rtl supported view the sidebar is overlaying the content, making it impossible to view and edit the page.