### PR TITLE
Solved issue where value passed to AS3CF_Utils::is_url not being a st…

### DIFF
--- a/classes/as3cf-filter.php
+++ b/classes/as3cf-filter.php
@@ -198,7 +198,7 @@ abstract class AS3CF_Filter {
 				continue;
 			}
 
-			if ( AS3CF_Utils::is_url( $value ) ) {
+			if ( is_string( $value ) && AS3CF_Utils::is_url( $value ) ) {
 				$instance[ $key ] = $this->process_content( $value, $cache, $to_cache );
 			}
 		}


### PR DESCRIPTION
Solved issue where value passed to AS3CF_Utils::is_url not being a string.

This problem appears in Wordpress Gallery widget when displaying multiple images:

Warning: preg_match() expects parameter 2 to be string, array given in ../wp-content/plugins/amazon-s3-and-cloudfront/classes/as3cf-utils.php on line 135

Solved it by checking if the value passed to AS3CF_Utils::is_url is a string.