### PR TITLE
Add a filter as3cf_upload_file_prefix to allow storage path changes

### DIFF
--- a/classes/amazon-s3-and-cloudfront.php
+++ b/classes/amazon-s3-and-cloudfront.php
@@ -1801,7 +1801,7 @@ class Amazon_S3_And_CloudFront extends AS3CF_Plugin_Base {
 			$prefix .= AS3CF_Utils::trailingslash_prefix( $this->get_object_version_string() );
 		}
 
-		return $prefix;
+		return apply_filters( 'as3cf_upload_file_prefix', $prefix );
 	}
 
 	/**


### PR DESCRIPTION
Being able to set an S3 path prefix in configuration is sometimes not enough.

My use-case is using cloudfront with MultilingualPress (implies multisite with subfolders), I need to be able to change storage path in S3 from something like eg. `https://blah.cloudfront.net/wp-content/uploads/sites/2/2018/11/05161540/one.jpg` to a prettier eg. `https://blah.cloudfront.net/french/wp-content/uploads/2018/11/05161540/one.jpg`

With this filter I can fine-tune storage location in S3.

