### PR TITLE
Add ACL filters for can_write and stream_flush

### DIFF
--- a/classes/providers/aws-provider.php
+++ b/classes/providers/aws-provider.php
@@ -538,13 +538,16 @@ class AWS_Provider extends Provider {
 	 * @return bool|string Error message on unexpected exception
 	 */
 	public function can_write( $bucket, $key, $file_contents ) {
-		try {
+		try {	
+			// Get the default ACL, but allow it to be adjusted via a filter.
+			$acl = apply_filters( 'as3cf_can_write_acl', self::DEFAULT_ACL );
+			
 			// Attempt to create the test file.
 			$this->upload_object( array(
 				'Bucket' => $bucket,
 				'Key'    => $key,
 				'Body'   => $file_contents,
-				'ACL'    => self::DEFAULT_ACL,
+				'ACL'    => $acl,
 			) );
 
 			// delete it straight away if created

--- a/classes/providers/streams/aws-s3-stream-wrapper.php
+++ b/classes/providers/streams/aws-s3-stream-wrapper.php
@@ -84,9 +84,10 @@ class AWS_S3_Stream_Wrapper extends StreamWrapper {
 
 		$options = stream_context_get_options( $context );
 
-		// Set the ACL as public by default
-		$options[ static::$wrapper ]['ACL'] = AWS_Provider::DEFAULT_ACL;
-
+		// Get the default ACL, but allow it to be adjusted via a filter.
+		$acl = apply_filters( 'as3cf_stream_acl', AWS_Provider::DEFAULT_ACL, $options );
+		$options[ static::$wrapper ]['ACL'] = $acl;
+		
 		$options = apply_filters( 'wpos3_stream_flush_params', $options ); // Backwards compatibility
 		$options = apply_filters( 'as3cf_stream_flush_params', $options );
 


### PR DESCRIPTION
- This removes the semi-false bucket write warning in the admin options when any other ACL than `public-read` is required for the AWS provider.
- This also allows for changing of the ACL for the `AWS_S3_Stream_Wrapper`, fixing issues when rescaling images if the ACL is other than `public-read`.

This would bring the ACL filters to:

```php
# Existing
add_filter('as3cf_upload_acl', [$this, 'adjust_upload_acl'], 10, 3);
add_filter('as3cf_upload_acl_sizes', [$this, 'adjust_upload_acl_sizes'], 10, 4);

# New
add_filter('as3cf_stream_acl', [$this, 'adjust_stream_acl'], 10, 2);
add_filter('as3cf_can_write_acl', [$this, 'adjust_can_write_acl'], 10, 1);
```

Fixes #518, and also somewhat mitigates the issues of #492.