### PR TITLE
Fix import of existing items

### DIFF
--- a/classes/items/item.php
+++ b/classes/items/item.php
@@ -539,7 +539,7 @@ abstract class Item {
 			$result = $wpdb->update( static::items_table(), $this->key_values(), array( 'id' => $this->id ), $this->formats(), array( '%d' ) );
 		}
 
-		if ( $result ) {
+		if ( $result !== false ) {
 			// Now that the item has an ID it should be (re)cached.
 			static::add_to_object_cache( $this );
 		} else {


### PR DESCRIPTION
If item exists in the as3cf_items table `wpdb::update` returns int 0, which is incorrectly regarded as error. Only boolean false indicates error, so I added a strict type check. In fact it is the behavior, that was present in the 2.3.1 version and the bug was introduced in the following commit:

https://github.com/deliciousbrains/wp-amazon-s3-and-cloudfront/commit/0142a3b9bd32c9d16529ab0d6f0bb0eeaf65715d#diff-319ee688c474fcd2a3bde8b6e7ee48ffL381