### PR TITLE
Add hook around returning region setting.

### DIFF
--- a/classes/amazon-s3-and-cloudfront.php
+++ b/classes/amazon-s3-and-cloudfront.php
@@ -570,7 +570,7 @@ class Amazon_S3_And_CloudFront extends AS3CF_Plugin_Base {
 
 		// Region
 		if ( false !== ( $region = $this->get_setting_region( $settings, $key, $default ) ) ) {
-			return $region;
+			return apply_filters( 'as3cf_setting_region', $region );
 		}
 
 		// Domain setting since 0.8


### PR DESCRIPTION
When region is found in settings the region filter will never get
applied and thus not possibly for userland to filter. This adds in the
filter if the region is returned from settings.