### PR TITLE
added 'as3cf_error_log_message' filter to AS3CF_Error::log()

### DIFF
--- a/classes/as3cf-error.php
+++ b/classes/as3cf-error.php
@@ -39,6 +39,11 @@ class AS3CF_Error {
 
 		$prefix .= ': ';
 
+		$message = apply_filters( 'as3cf_error_log_message', $message, $prefix );
+		if ( empty( $message ) ) {
+			return;
+		}
+
 		if ( is_array( $message ) || is_object( $message ) ) {
 			error_log( $prefix . print_r( $message, true ) );
 		} else {


### PR DESCRIPTION
## Which issue is it related to?
#635 

## What did I do?
Added a filter to stop logs from being recorded from the plugin specifications.

## How did I test?
 I installed the following filter in mu-plugins and confirmed that logs were not output only at that time.

```
		add_filter(
			'as3cf_error_log_message',
			function( $message, $prefix ) {
				if ( 0 === strpos( $message, 'AS3CF: Could not get Block All Public Access status:' ) ) {
					$message = '';
				}
				return $message;
			},
			10, 2
		);
```
