### PR TITLE
Update amazon-s3-and-cloudfront.php - fix warning and depreciation waring

### DIFF
--- a/classes/amazon-s3-and-cloudfront.php
+++ b/classes/amazon-s3-and-cloudfront.php
@@ -1564,8 +1564,8 @@ class Amazon_S3_And_CloudFront extends AS3CF_Plugin_Base {
 	function does_file_exist_local( $filename, $time ) {
 		global $wpdb;
 
-		$path = wp_upload_dir( $time );
-		$path = ltrim( $path['subdir'], '/' );
+		$upload_dir = wp_upload_dir( $time );
+		$path =  isset( $upload_dir['subdir'] ) ? ltrim( $upload_dir['subdir'], '/' ) : '';
 
 		if ( '' !== $path ) {
 			$path = trailingslashit( $path );


### PR DESCRIPTION
- Fix warnings/deprication notice if `subdir` is not defined.
- Improve code so that array is not reassigned to a string.