### PR TITLE
fix-prevention-of-mysql-to-use-the-index

### DIFF
--- a/classes/items/item.php
+++ b/classes/items/item.php
@@ -1426,9 +1426,9 @@ abstract class Item {
 		}
 
 		$sql = $wpdb->prepare(
-			"SELECT * FROM " . static::items_table() . " WHERE (path LIKE %s OR original_path LIKE %s);",
-			'%' . $path,
-			'%' . $path
+			"SELECT * FROM " . static::items_table() . " WHERE (path = %s OR original_path = %s);",
+			'app/' . $path,
+			'app/' . $path
 		);
 
 		$results = $wpdb->get_results( $sql );


### PR DESCRIPTION
You are using % at the front of the like, this prevents mysql from using an index. It has to go through 20k records every single time. (and there are a lot of those requests)

Simple fix is to remove the % and replace it with app/ 

Also you can use = instead of LIKE.

Notes:
We use that plugin in one of our websites, and we increased the speed of requests by 50 times at least.